### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/service/worker/scheduler/calendar.go
+++ b/service/worker/scheduler/calendar.go
@@ -30,7 +30,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
+	"math"
 	schedulepb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -444,6 +444,9 @@ func makeRange(s, field, def string, minVal, maxVal int, parseMode parseMode) ([
 			}
 			if step < 1 {
 				return nil, fmt.Errorf("%s has invalid Step", field)
+			}
+			if step > math.MaxInt32 {
+				return nil, fmt.Errorf("%s Step is too large (max %d)", field, math.MaxInt32)
 			}
 			hasStep = true
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/TR1LL-R3C0RD5/temporal/security/code-scanning/7](https://github.com/TR1LL-R3C0RD5/temporal/security/code-scanning/7)

To fix the problem, we should ensure that the value of `step` is within the valid range for `int32` before casting. The best way is to add an explicit upper bound check after parsing `step` from the string, using the constant `math.MaxInt32` from the `math` package. If the value is out of bounds, return an error indicating that the step value is too large. This change should be made in the `makeRange` function, after line 445 and before any use of `step`. We will need to import the `math` package if it is not already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
